### PR TITLE
Default google search results to English

### DIFF
--- a/src/main/java/com/agilitas/example/GoogleResultsPage.java
+++ b/src/main/java/com/agilitas/example/GoogleResultsPage.java
@@ -15,16 +15,15 @@ public class GoogleResultsPage {
 
     public boolean hasResultTitled(String expectedTitle) {
         LOGGER.info("Found {} search results",results.size());
-        boolean matchingTitle = false;
-                for(WebElement result :results)
-                {
-                    String resultTitle = result.getText();
-                    LOGGER.info("Looking at {}", resultTitle);
-                    if (resultTitle.equalsIgnoreCase(expectedTitle)) {
-                        LOGGER.info("{} matches {}", resultTitle, expectedTitle);
-                        return true;
-                    }
-                }
+        for(WebElement result :results)
+        {
+            String resultTitle = result.getText();
+            LOGGER.info("Looking at {}", resultTitle);
+            if (resultTitle.equalsIgnoreCase(expectedTitle)) {
+                LOGGER.info("{} matches {}", resultTitle, expectedTitle);
+                return true;
+            }
+        }
 
         LOGGER.warn("Didn't get a match for "+expectedTitle);
         return false;

--- a/src/test/java/com/agilitas/example/steps/MyStepdefs.java
+++ b/src/test/java/com/agilitas/example/steps/MyStepdefs.java
@@ -65,6 +65,10 @@ public class MyStepdefs implements En {
 
     public MyStepdefs() {
         Given("^I've opened the google home page$", () -> {
+            //First we need to set the language. When tests run on a non-UK CI server you might
+            //Get results in different languages which cause the test to fail
+            driver.get("https://www.google.com/preferences?hl=en-GB&fg=1#languages");
+            driver.findElement(By.cssSelector("#langten > div > span.jfk-radiobutton-label")).click();
             driver.get("https://www.google.com");
             SeleniumUtils.waitForElementVisible(driver, By.cssSelector("input[name='q']"));
         });


### PR DESCRIPTION
Updating step definitions to set the google search result language before running the test. This way we should always get English search
results regardless of where the tests are running from